### PR TITLE
Complete product name migration from kchfgt to shekere in GitHub work…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,13 +70,13 @@ jobs:
       - name: Package
         run: >
           zip --junk-paths
-          kchfgt-aarch64-apple-darwin.zip target/aarch64-apple-darwin/release/kchfgt
+          shekere-aarch64-apple-darwin.zip target/aarch64-apple-darwin/release/shekere
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: kchfgt-aarch64-apple-darwin
-          path: kchfgt-aarch64-apple-darwin.zip
+          name: shekere-aarch64-apple-darwin
+          path: shekere-aarch64-apple-darwin.zip
 
   release:
     needs: [build]
@@ -88,12 +88,12 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          name: kchfgt-aarch64-apple-darwin
+          name: shekere-aarch64-apple-darwin
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: kchfgt-aarch64-apple-darwin.zip
+          files: shekere-aarch64-apple-darwin.zip
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
…flows

- Update build.yaml to use 'shekere' instead of 'kchfgt' in:
  - Package step: zip file name and binary path
  - Upload artifact: artifact name and file path
  - Download artifact: artifact name
  - Release step: release file name

All references to the old product name 'kchfgt' have been removed from the repository.

🤖 Generated with [Claude Code](https://claude.ai/code)