### PR TITLE
Update to Rust Edition 2024 and bump version to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "shekere"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["katk3n"]
 description = "Creative coding tool with shaders and sounds"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/katk3n/shekere"
 

--- a/src/audio_stream.rs
+++ b/src/audio_stream.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use cpal::{
-    traits::{DeviceTrait, HostTrait, StreamTrait},
     Stream,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 use ringbuf::{
+    HeapRb,
     traits::{Producer, Split},
     wrap::caching::Caching,
-    HeapRb,
 };
 
 pub const NUM_SAMPLES: usize = 2048;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub async fn run(conf: &Config, conf_dir: &Path) {
     env_logger::init();
     let event_loop = EventLoop::new().unwrap();
     let window = WindowBuilder::new()
-        .with_title("KaCHoFuGeTsu")
+        .with_title("shekere")
         .with_inner_size(LogicalSize::new(conf.window.width, conf.window.height))
         .build(&event_loop)
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use shekere::run;
 use shekere::Config;
+use shekere::run;
 use std::path::Path;
 
 #[derive(Debug, Parser)]

--- a/src/osc.rs
+++ b/src/osc.rs
@@ -1,5 +1,5 @@
-use async_std::channel::unbounded;
 use async_std::channel::Receiver;
+use async_std::channel::unbounded;
 use async_std::net::{SocketAddrV4, UdpSocket};
 use async_std::task;
 use rosc::OscPacket;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
+use crate::ShaderConfig;
 use crate::shader_preprocessor::ShaderPreprocessor;
 use crate::vertex::Vertex;
-use crate::ShaderConfig;
 use wgpu::{BindGroupLayout, Device, RenderPipeline, SurfaceConfiguration};
 
 pub fn create_pipeline(

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,4 @@
+use crate::Config;
 use crate::bind_group_factory::BindGroupFactory;
 use crate::hot_reload::HotReloader;
 use crate::shader_preprocessor::ShaderPreprocessor;
@@ -9,7 +10,6 @@ use crate::uniforms::spectrum_uniform::SpectrumUniform;
 use crate::uniforms::time_uniform::TimeUniform;
 use crate::uniforms::window_uniform::WindowUniform;
 use crate::vertex::{INDICES, VERTICES};
-use crate::Config;
 
 use std::path::{Path, PathBuf};
 use wgpu::util::DeviceExt;

--- a/src/uniforms/midi_uniform.rs
+++ b/src/uniforms/midi_uniform.rs
@@ -248,14 +248,18 @@ mod tests {
         MidiUniform::handle_midi_message(&data, &message);
 
         let data_guard = data.lock().unwrap();
-        assert!(data_guard
-            .notes
-            .iter()
-            .all(|vec4| vec4.iter().all(|&x| x == 0.0)));
-        assert!(data_guard
-            .cc
-            .iter()
-            .all(|vec4| vec4.iter().all(|&x| x == 0.0)));
+        assert!(
+            data_guard
+                .notes
+                .iter()
+                .all(|vec4| vec4.iter().all(|&x| x == 0.0))
+        );
+        assert!(
+            data_guard
+                .cc
+                .iter()
+                .all(|vec4| vec4.iter().all(|&x| x == 0.0))
+        );
     }
 
     #[test]
@@ -270,9 +274,11 @@ mod tests {
         MidiUniform::handle_midi_message(&data, &message);
 
         let data_guard = data.lock().unwrap();
-        assert!(data_guard
-            .notes
-            .iter()
-            .all(|vec4| vec4.iter().all(|&x| x == 0.0)));
+        assert!(
+            data_guard
+                .notes
+                .iter()
+                .all(|vec4| vec4.iter().all(|&x| x == 0.0))
+        );
     }
 }

--- a/src/uniforms/spectrum_uniform.rs
+++ b/src/uniforms/spectrum_uniform.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use cpal::Stream;
 use ringbuf::{
+    HeapRb,
     traits::{Consumer, Observer},
     wrap::caching::Caching,
-    HeapRb,
 };
 use spectrum_analyzer::scaling::*;
 use spectrum_analyzer::windows::hann_window;
-use spectrum_analyzer::{samples_fft_to_spectrum, FrequencyLimit};
+use spectrum_analyzer::{FrequencyLimit, samples_fft_to_spectrum};
 use wgpu::util::DeviceExt;
 
 use crate::{


### PR DESCRIPTION
- Update Cargo.toml edition from 2021 to 2024
- Bump version from 0.8.0 to 0.8.1
- Fix window title from "KaCHoFuGeTsu" to "shekere"
- Apply cargo fmt for consistent import ordering
- All tests pass and build succeeds with Edition 2024

🤖 Generated with [Claude Code](https://claude.ai/code)